### PR TITLE
Return $this in apply method of data patch

### DIFF
--- a/Setup/Patch/Data/AddCustomerCurrencyAttribute.php
+++ b/Setup/Patch/Data/AddCustomerCurrencyAttribute.php
@@ -62,5 +62,7 @@ class AddCustomerCurrencyAttribute implements DataPatchInterface
         $attribute = $this->eavConfig->getAttribute(Customer::ENTITY, self::ATTRIBUTE_NAME);
 
         $attribute->setData('used_in_forms', ['adminhtml_customer'])->save();
+
+        return $this;
     }
 }


### PR DESCRIPTION
The PatchInterface this class implements, expects the `apply()` method to return `$this`: https://github.com/magento/magento2/blob/2.4.6/lib/internal/Magento/Framework/Setup/Patch/PatchInterface.php#L31

Was found using [phpstan](https://github.com/phpstan/phpstan) running on level 1:
```
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Line   module-customer-price/Setup/Patch/Data/AddCustomerCurrencyAttribute.php
 ------ -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  64     Method Commerce365\CustomerPrice\Setup\Patch\Data\AddCustomerCurrencyAttribute::apply() should return $this(Commerce365\CustomerPrice\Setup\Patch\Data\AddCustomerCurrencyAttribute) but return statement is missing.
```