### PR TITLE
Allow certain configuration settings to be configured on website scop…

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Commerce365\CustomerPrice\Model;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
 
 class Config
 {
@@ -27,7 +28,7 @@ class Config
      */
     public function isAjaxEnabled(): bool
     {
-        return $this->scopeConfig->isSetFlag(self::XML_PATH_AJAX_ENABLED);
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_AJAX_ENABLED, ScopeInterface::SCOPE_STORE);
     }
 
     /**
@@ -35,7 +36,7 @@ class Config
      */
     public function isCachingEnabled(): bool
     {
-        return $this->scopeConfig->isSetFlag(self::XML_PATH_CACHE_ENABLE);
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_CACHE_ENABLE, ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
     }
 
     /**
@@ -43,7 +44,7 @@ class Config
      */
     public function isHidePricesGuest(): bool
     {
-        return $this->scopeConfig->isSetFlag(self::XML_PATH_HIDE_PRICES);
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_HIDE_PRICES, ScopeInterface::SCOPE_STORE);
     }
 
     /**
@@ -51,16 +52,16 @@ class Config
      */
     public function useSpecialPrice(): bool
     {
-        return $this->scopeConfig->isSetFlag(self::XML_PATH_SPECIAL_PRICE);
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_SPECIAL_PRICE, ScopeInterface::SCOPE_STORE);
     }
 
     public function getCacheHours()
     {
-        return $this->scopeConfig->getValue(self::XML_PATH_CACHE_HOURS);
+        return $this->scopeConfig->getValue(self::XML_PATH_CACHE_HOURS, ScopeConfigInterface::SCOPE_TYPE_DEFAULT);
     }
 
     public function showPricePerUom()
     {
-        return $this->scopeConfig->isSetFlag(self::XML_PATH_SHOW_UOM);
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_SHOW_UOM, ScopeInterface::SCOPE_STORE);
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -2,13 +2,13 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
         <section id="commerce365config_general">
-            <group id="b2b_pricing" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="1">
+            <group id="b2b_pricing" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>B2B Pricing</label>
-                <field id="ajax_enabled" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="0" showInStore="1">
+                <field id="ajax_enabled" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>B2B Pricing Enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="db_caching_enabled" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="0" showInStore="1">
+                <field id="db_caching_enabled" translate="label" type="select" sortOrder="2" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>DB Caching</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment><![CDATA[This type of caching works only with Ajax Price Loading]]></comment>
@@ -16,7 +16,7 @@
                         <field id="ajax_enabled">1</field>
                     </depends>
                 </field>
-                <field id="cache_hours" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="0" showInStore="1">
+                <field id="cache_hours" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="0" showInStore="0">
                     <label>Cache Hours</label>
                     <comment><![CDATA[Enter number of hours for DB Caching]]></comment>
                     <validate>validate-greater-than-zero validate-number required-entry</validate>
@@ -25,26 +25,26 @@
                         <field id="db_caching_enabled">1</field>
                     </depends>
                 </field>
-                <field id="flush_cache" translate="label comment" type="button" sortOrder="300" showInDefault="1">
+                <field id="flush_cache" translate="label comment" type="button" sortOrder="300" showInDefault="1" showInWebsite="0" showInStore="0">
                     <frontend_model>Commerce365\CustomerPrice\Block\Adminhtml\System\Config\Buttons\FlushCache</frontend_model>
                     <depends>
                         <field id="ajax_enabled">1</field>
                         <field id="db_caching_enabled">1</field>
                     </depends>
                 </field>
-                <field id="hide_prices_guest" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="0" showInStore="1">
+                <field id="hide_prices_guest" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Hide Prices for Guest Users</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <depends>
                         <field id="ajax_enabled">1</field>
                     </depends>
                 </field>
-                <field id="use_special_price" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="0" showInStore="1">
+                <field id="use_special_price" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Use Special Price</label>
                     <comment>Customer Price cache will be cleaned after you change this setting</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="show_priceperuom" translate="label" type="select" sortOrder="310" showInDefault="1" showInWebsite="0" showInStore="1">
+                <field id="show_priceperuom" translate="label" type="select" sortOrder="310" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Show Price Per UOM   </label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>


### PR DESCRIPTION
…e, and make sure when fetching the values, they are fetched from the correct scope.


Changes:
- most config settings where configurable on storeview scope but not on website scope, which is strange, these have been corrected
- some config settings shouldn't be allowed to be configured on storeview scope (the ones that relate to caches) I think, but I might be wrong?
- When getting the values of the configurations in the Config Model, previously it defaulted to the 'default' scope, even though you were able to configure some values on storeview scope


Purpose of this PR:
- Having the ability to hide prices on certain websites only


Questions:

It would be nice to see some extra explanations of certain config values in the backoffice, like
- `Show Price Per UOM` => what does UOM stand for?
- `DB Caching` => what purpose does this has, what are the benefits or the downsides of enabling this?
- `DB Caching` => mentions 'Ajax loading', even though the config setting that's called like that behind the scenes is called `B2B Pricing Enabled`, which is kind of confusing