### PR TITLE
Bugfix/28 fix lt 2.4.5 compatibility

### DIFF
--- a/Model/ResourceModel/GetProductTypeById.php
+++ b/Model/ResourceModel/GetProductTypeById.php
@@ -1,0 +1,46 @@
+<?php
+namespace Commerce365\CustomerPrice\Model\ResourceModel;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Framework\App\ResourceConnection;
+
+/**
+ * Get product type ID by product ID.
+ */
+class GetProductTypeById
+{
+    /**
+     * @var ResourceConnection
+     */
+    private $resource;
+
+    /**
+     * @param ResourceConnection $resource
+     */
+    public function __construct(
+        ResourceConnection $resource
+    ) {
+        $this->resource = $resource;
+    }
+
+    /**
+     * Retrieve product type by its product ID
+     *
+     * @param int $productId
+     * @return string
+     */
+    public function execute(int $productId): string
+    {
+        $connection = $this->resource->getConnection();
+        $productTable = $this->resource->getTableName('catalog_product_entity');
+
+        $select = $connection->select()
+            ->from(
+                $productTable,
+                ProductInterface::TYPE_ID
+            )->where('entity_id = ?', $productId);
+
+        $result = $connection->fetchOne($select);
+        return $result ?: '';
+    }
+}

--- a/Model/ResourceModel/GetProductTypeByIdFactory.php
+++ b/Model/ResourceModel/GetProductTypeByIdFactory.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+namespace Commerce365\CustomerPrice\Model\ResourceModel;
+
+use Magento\Framework\ObjectManagerInterface;
+
+/**
+ * Added for Magento <2.4.5 compatibility
+ * \Magento\Catalog\Model\ResourceModel\GetProductTypeById was introduced in version 2.4.5
+ */
+class GetProductTypeByIdFactory
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    protected ObjectManagerInterface $objectManager;
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(
+        ObjectManagerInterface $objectManager
+    ) {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * Create object, first we check if Magento default exists, otherwise we use fallback
+     *
+     * @param array $data
+     * @return mixed|string
+     */
+    public function create(array $data = array())
+    {
+        if (class_exists('Magento\Catalog\Model\ResourceModel\GetProductTypeById')) {
+            $instanceName = 'Magento\Catalog\Model\ResourceModel\GetProductTypeById';
+        } else {
+            $instanceName = GetProductTypeById::class;
+        }
+        return $this->objectManager->create($instanceName, $data);
+    }
+}

--- a/Service/GetProductResponseData.php
+++ b/Service/GetProductResponseData.php
@@ -1,28 +1,37 @@
 <?php
-
 declare(strict_types=1);
-
 namespace Commerce365\CustomerPrice\Service;
 
+use Commerce365\CustomerPrice\Model\ResourceModel\GetProductTypeById;
 use Commerce365\CustomerPrice\Service\PriceInfoProvider\PriceInfoProviderInterface;
-use Magento\Catalog\Model\ResourceModel\GetProductTypeById;
+use Commerce365\CustomerPrice\Model\ResourceModel\GetProductTypeByIdFactory;
 use RuntimeException;
 
 class GetProductResponseData
 {
+    /**
+     * @var array
+     */
     private array $priceInfoProviders;
-    private GetProductTypeById $getProductTypeById;
 
     /**
-     * @param GetProductTypeById $getProductTypeById
+     * Type depends on factory result
+     *
+     * @var GetProductTypeById
+     */
+    private $getProductTypeById;
+
+    /**
+     * @param GetProductTypeByIdFactory $getProductTypeByIdFactory
      * @param array $priceInfoProviders
      */
     public function __construct(
-        GetProductTypeById $getProductTypeById,
+        GetProductTypeByIdFactory $getProductTypeByIdFactory,
         array $priceInfoProviders
     ) {
         $this->priceInfoProviders = $priceInfoProviders;
-        $this->getProductTypeById = $getProductTypeById;
+        /** Added for Magento <2.4.5 compatibility */
+        $this->getProductTypeById = $getProductTypeByIdFactory->create();
     }
 
     public function execute($product, $productId): array


### PR DESCRIPTION
Fix for https://github.com/NVision-Commerce-Solutions/module-customer-price/issues/28

Create a factory to determine if the original Magento class exists. If not it will use a local class. I did not want to load the product. This should be removed at some point if you drop support for certain versions, but composer.json should force magento module version if you decide to do that.