### PR TITLE
Clone product collection when getting Ids for request

### DIFF
--- a/Service/GetProductIdsForRequest.php
+++ b/Service/GetProductIdsForRequest.php
@@ -16,7 +16,9 @@ class GetProductIdsForRequest
     public function execute(Collection $collection): array
     {
         $productIds = [];
-        foreach ($collection as $product) {
+        $collectionClone = clone $collection;
+        
+        foreach ($collectionClone as $product) {
             if ($product->getTypeId() !== Type::DEFAULT_TYPE) {
                 $childrenIds = $product->getTypeInstance()->getChildrenIds($product->getId());
                 $childrenIds = array_shift($childrenIds);
@@ -27,6 +29,8 @@ class GetProductIdsForRequest
                 $productIds[] = $product->getId();
             }
         }
+
+        unset($collectionClone);
 
         return array_unique($productIds);
     }


### PR DESCRIPTION
Looping through a product collection caches the results into the collection. When other processes later change this collection without clearing it those changes can be ignored. Resulting in hard-to-debug bugs. 

By cloning the collection before looping over it these bugs can be prevented with relative low overhead.

This problem doesn't generally happen on a clean install, but in combination with other code this can happen. In our case the culprit was the Anowave Google Analytic module that calls getLoadedProductCollection before pagination and sorting is applied.

It is good to mention that there is still an issue with compatibility between these two modules after this fix has been done. Because as it stands right now the Anowave module will force every product in a category to be cached instead of only the products shown on the page at that time. 

There might be a possibility to fix this by re-implementing the logic Anowave uses to re-build the sorted collection after they get it. But I'm not sure you guys want to invest time into that level of compatibility.