### PR TITLE
Update GetPrice.php - Add if statement

### DIFF
--- a/Service/PriceBox/GetPrice.php
+++ b/Service/PriceBox/GetPrice.php
@@ -30,6 +30,10 @@ class GetPrice
             return '';
         }
 
+         if ($this->customerSessionFactory->create()->isLoggedIn()) {
+             return $default;
+         }
+
         return '<div class="commerce365-price-placeholder"></div>';
     }
 }


### PR DESCRIPTION
Without this change, we don't receive any prices from Business Central on Category Pages in Magento. We do receive the price on product pages, but they are not listed on category pages.

- We only show prices for logged in users.

- When we add the new if statement it shows correctly. https://i.imgur.com/PKBRuDm.png

We are not sure this fix is 100% correct, but for us it works now. Can you please review?

Thanks,