### PR TITLE
Skip final_price when $minProduct does not exist

### DIFF
--- a/view/base/templates/product/price/grouped/final_price.phtml
+++ b/view/base/templates/product/price/grouped/final_price.phtml
@@ -9,18 +9,21 @@ $minProduct = $block->getSaleableItem()
     ->getPrice(\Magento\Catalog\Pricing\Price\FinalPrice::PRICE_CODE)
     ->getMinProduct();
 
-if ($minProduct) {
-    $amountRender = $block->getRendererPool()
-        ->createAmountRender(
-            $minProduct->getPriceInfo()->getPrice('final_price')->getAmount(),
-            $minProduct,
-            $minProduct->getPriceInfo()->getPrice('final_price'),
-            ['include_container' => true]
-        );
+if (!$minProduct) {
+    return;
 }
+
+$amountRender = $block->getRendererPool()
+    ->createAmountRender(
+        $minProduct->getPriceInfo()->getPrice('final_price')->getAmount(),
+        $minProduct,
+        $minProduct->getPriceInfo()->getPrice('final_price'),
+        ['include_container' => true]
+    );
+
 ?>
 <div class="price-box">
-    <?php if ($minProduct && \Magento\Framework\Pricing\Render::ZONE_ITEM_VIEW != $block->getZone()) : ?>
+    <?php if (\Magento\Framework\Pricing\Render::ZONE_ITEM_VIEW != $block->getZone()) : ?>
     <p class="minimal-price">
         <span class="price-label"><?= $block->escapeHtml(__('Starting at')) ?></span><?= $amountRender->toHtml() ?>
     </p>


### PR DESCRIPTION
In case there are no (available) products, the `$additionalData = $minProduct->getData('additional_price_data');` will fail.

> Error: Call to a member function getData() on null in [..]/vendor/commerce365/module-customer-price/view/base/templates/product/price/grouped/final_price.phtml:29

You already check for $minProduct twice, so better to just return early when it's not there.